### PR TITLE
Remove check to see if app exists in /data/local/webapps when uninstalling

### DIFF
--- a/fxos_appgen/generator.py
+++ b/fxos_appgen/generator.py
@@ -232,45 +232,44 @@ def uninstall_app(app_name, adb_path=None, script_timeout=5000):
 
     installed_app_name = app_name.lower()
     installed_app_name = installed_app_name.replace(" ", "-")
-    if dm.dirExists("/data/local/webapps/%s" % installed_app_name):
-        ret = dm.forward("tcp:2828", "tcp:2828")
-        if ret != 0:
-            raise Exception("Can't use localhost:2828 for port forwarding." \
-                        "Is something else using port 2828?")
+    ret = dm.forward("tcp:2828", "tcp:2828")
+    if ret != 0:
+        raise Exception("Can't use localhost:2828 for port forwarding." \
+                    "Is something else using port 2828?")
 
-        m = Marionette()
-        m.start_session()
-        uninstall_app = """
-        var uninstallWithName = function(name) {
-            let apps = window.wrappedJSObject.applications || window.wrappedJSObject.Applications;
-            let installedApps = apps.installedApps;
-            for (let manifestURL in installedApps) {
-              let app = installedApps[manifestURL];
-              let origin = null;
-              let entryPoints = app.manifest.entry_points;
-              if (entryPoints) {
-                for (let ep in entryPoints) {
-                  let currentEntryPoint = entryPoints[ep];
-                  let appName = currentEntryPoint.name;
-                  if (name == appName.toLowerCase()) {
-                    window.wrappedJSObject.navigator.mozApps.mgmt.uninstall(app);
-                    return true;
-                  }
-                }
-              } else {
-                let appName = app.manifest.name;
-                if (name == appName.toLowerCase()) {
-                  window.wrappedJSObject.navigator.mozApps.mgmt.uninstall(app);
-                  return true;
-                }
+    m = Marionette()
+    m.start_session()
+    uninstall_app = """
+    var uninstallWithName = function(name) {
+        let apps = window.wrappedJSObject.applications || window.wrappedJSObject.Applications;
+        let installedApps = apps.installedApps;
+        for (let manifestURL in installedApps) {
+          let app = installedApps[manifestURL];
+          let origin = null;
+          let entryPoints = app.manifest.entry_points;
+          if (entryPoints) {
+            for (let ep in entryPoints) {
+              let currentEntryPoint = entryPoints[ep];
+              let appName = currentEntryPoint.name;
+              if (name == appName.toLowerCase()) {
+                window.wrappedJSObject.navigator.mozApps.mgmt.uninstall(app);
+                return true;
               }
             }
-          };
-        return uninstallWithName("%s");
-        """
-        m.set_script_timeout(script_timeout)
-        m.execute_script(uninstall_app % app_name.lower())
-        m.delete_session()
+          } else {
+            let appName = app.manifest.name;
+            if (name == appName.toLowerCase()) {
+              window.wrappedJSObject.navigator.mozApps.mgmt.uninstall(app);
+              return true;
+            }
+          }
+        }
+      };
+    return uninstallWithName("%s");
+    """
+    m.set_script_timeout(script_timeout)
+    m.execute_script(uninstall_app % app_name.lower())
+    m.delete_session()
 
 
 def install_app(app_name, app_path, adb_path=None, script_timeout=5000):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-PACKAGE_VERSION = '0.2.5'
+PACKAGE_VERSION = '0.2.6'
 deps = ['marionette_client>=0.7.1',
         'mozdevice >= 0.33']
 


### PR DESCRIPTION
This check prevents me from removing my web installed app, which has a uuid for a directory name instead of something based on the appname.

Removing an app that does not exist doesn't seem to have any bad effect, so I don't think this check is necessary.
