### PR TITLE
Allow details_file=None when all_perms=None in create_details

### DIFF
--- a/fxos_appgen/generator.py
+++ b/fxos_appgen/generator.py
@@ -118,8 +118,9 @@ def generate_app(app_name, details_file=None, uninstall=False, install=False,
 
 def create_details(version, details_file=None, all_perms=None):
     """
-    You need to pass in either a details_file, or all_perms=True,
-    or all_perms=True and a details_file
+    You may pass in either a details_file, or all_perms=True,
+    or all_perms=True and a details_file. Otherwise, the default
+    is to create the details with no permissions.
     """
     details = None
     if all_perms:
@@ -140,8 +141,12 @@ def create_details(version, details_file=None, all_perms=None):
         else:
             details = perms
     else:
-        with open(details_file, "r") as f:
-            details = json.load(f)
+        if details_file:
+            #User has provided us with a details_file
+            with open(details_file, "r") as f:
+                details = json.load(f)
+        else:
+            details = {"permissions": {}}
     return details
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-PACKAGE_VERSION = '0.2.9'
+PACKAGE_VERSION = '0.2.10'
 deps = ['marionette_client>=0.7.1',
         'mozdevice >= 0.33']
 


### PR DESCRIPTION
I would like the create_details function to default to no permissions if details_file is None and all_perms is None, rather than having to make a separate json details file to create an application with no permissions.
