### PR TITLE
Bug 1116879 - Fix perms for 2.1

### DIFF
--- a/fxos_appgen/resources/2.1/complete_permissions.json
+++ b/fxos_appgen/resources/2.1/complete_permissions.json
@@ -17,7 +17,7 @@
     "camera": {},
     "cellbroadcast": {},
     "contacts": {
-      "access": "readwritecreate"
+      "access": "readwrite"
     },
     "deprecated-hwvideo": {},
     "desktop-notification": {},
@@ -28,16 +28,16 @@
       "access": "read"
     },
     "device-storage:music": {
-      "access": "readwritecreate"
+      "access": "readwrite"
     },
     "device-storage:pictures": {
-      "access": "readwritecreate"
+      "access": "readwrite"
     },
     "device-storage:sdcard": {
-      "access": "readwritecreate"
+      "access": "readwrite"
     },
     "device-storage:videos": {
-      "access": "readwritecreate"
+      "access": "readwrite"
     },
     "downloads": {},
     "feature-detection": {},
@@ -82,7 +82,7 @@
     "tcp-socket": {},
     "telephony": {},
     "test-permission": {
-      "access": "readwritecreate"
+      "access": "readwrite"
     },
     "themeable": {},
     "time": {},

--- a/fxos_appgen/resources/extract_permissions.js
+++ b/fxos_appgen/resources/extract_permissions.js
@@ -27,13 +27,22 @@ function extract_from(name)
 
     json = {}
     json.permissions = {}
+    // see http://dxr.mozilla.org/mozilla-central/source/modules/libpref/init/all.js#796
+    forbidden_perms = 'engineering-mode,embed-apps,embed-widgets';
     for (name in names) {
       permission = names[name];
       if ('access' in PermissionsTable[permission]) {
         access = PermissionsTable[permission].access;
-        json.permissions[permission] = {'access': access.join('')}
+        if (access.indexOf('write') != -1 && access.indexOf('create') != -1) {
+          access.splice(access.indexOf('create'), 1);
+        }
+        if (forbidden_perms.indexOf(permission) == -1) {
+          json.permissions[permission] = {'access': access.join('')}
+        }
       } else {
-        json.permissions[permission] = {}
+        if (forbidden_perms.indexOf(permission) == -1) {
+          json.permissions[permission] = {}
+        }
       }
     }
 


### PR DESCRIPTION
'readwritecreate' isn't a valid permission; if both write and create exist, just use 'readwrite'.  Also exclude forbidden permissions that cause an app to fail to load.