### PR TITLE
Add support for specifying device serial

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-PACKAGE_VERSION = '0.11'
+PACKAGE_VERSION = '0.12'
 deps = ['marionette_client>=0.7.1',
         'mozdevice >= 0.33']
 


### PR DESCRIPTION
It is useful for mozbench to be able to specify the device serial number.

I tested this using the command line options that fxos-appgen provides and a with certsuite run. The certsuite run had some problems, but was able to uninstall, install and launch apps properly, so I'm thinking that the problems I saw were due to flakiness with the wireless network in Toronto and not with these changes.